### PR TITLE
Add `splitAfterFirstAttribute` option for splitting attributes starting at the 2nd attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,6 +88,12 @@
 					"default": [],
 					"description": "Your preferred order for attributes e.g. [\"v-if\", \"v-else\", \"v-\", \"@click\", \"@focus\", \"@\"]",
 					"scope": "resource"
+				},
+				"splitHTMLAttributes.splitAfterFirstAttribute": {
+					"type": "boolean",
+					"default": false,
+					"description": "Split arguments after first attribute, left-aligning with it.",
+					"scope": "resource"
 				}
 			}
 		}

--- a/src/extension.js
+++ b/src/extension.js
@@ -27,6 +27,7 @@ function activate(context) {
 		let useSpacesForTabs = config.get("useSpacesForTabs")
 		let closingBracketOnNewLine = config.get("closingBracketOnNewLine")
 		let sortOrder = config.get("sortOrder")
+		let splitAfterFirstAttribute = config.get("splitAfterFirstAttribute")
 
 		// get document & selection
 		const document = editor.document
@@ -168,6 +169,13 @@ function activate(context) {
 					})
 				}
 				else {
+					if (splitAfterFirstAttribute && sortedAttributesArray.length > 0) {
+						let item = sortedAttributesArray[0]
+						textSplit[i] += ' ' + item
+						sortedAttributesArray.shift()
+						// reuse indentationString for additionaly needed whitespace
+						indentationString += ' '.repeat(openingTag.length - joinCharacter.length)
+					}
 					sortedAttributesArray.forEach(item => {
 						textSplit[i] += joinCharacter + initialWhitespace + indentationString + item
 					})


### PR DESCRIPTION
This left-aligns all split attributes with the first one

i.e.:

```
<foo bar="baz"
     baz="foo"
/>
```