### PR TITLE
Added the auto indent setting.

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,16 +65,21 @@
 		"configuration": {
 			"title": "Split HTML Attributes",
 			"properties": {
-				"splitHTMLAttributes.tabSize": {
-					"type": "number",
-					"default": 2,
-					"description": "Number of spaces for indentation.",
-					"scope": "resource"
-				},
-				"splitHTMLAttributes.useSpacesForTabs": {
-					"type": "boolean",
-					"default": true,
-					"description": "Use spaces for tabs.",
+				"splitHTMLAttributes.indentType": {
+					"type": "string",
+					"default": "Auto",
+					"enum": [
+						"Auto",
+						"Tab",
+						"Spaces 0",
+						"Spaces 1",
+						"Spaces 2",
+						"Spaces 3",
+						"Spaces 4",
+						"Spaces 5",
+						"Spaces 6"
+					],
+					"description": "What indents to use.",
 					"scope": "resource"
 				},
 				"splitHTMLAttributes.closingBracketOnNewLine": {

--- a/src/extension.js
+++ b/src/extension.js
@@ -23,10 +23,21 @@ function activate(context) {
 
 		// get config
 		let config = vscode.workspace.getConfiguration('splitHTMLAttributes', editor.document.uri)
-		let tabSize = config.get("tabSize")
-		let useSpacesForTabs = config.get("useSpacesForTabs")
 		let closingBracketOnNewLine = config.get("closingBracketOnNewLine")
 		let sortOrder = config.get("sortOrder")
+		
+		// get indent options
+		let tabSize, useSpacesForTabs, indentType = config.get("indentType");
+		if (indentType.toLowerCase() === "auto") {
+			tabSize = editor.options.tabSize
+			useSpacesForTabs = editor.options.insertSpaces
+		} else if (indentType.toLowerCase() === "tab") {
+			tabSize = 1;
+			useSpacesForTabs = false;
+		} else {
+			tabSize = parseInt(indentType);
+			useSpacesForTabs = true;
+		}
 
 		// get document & selection
 		const document = editor.document


### PR DESCRIPTION
Hello @dannyconnell.

I often work with different types of indents, and it is quite not convenient to constantly change the settings, moving from the project to the project.

I propose the opportunity to set the automatic determination of the indent type depending on the editor options by using the ```editor.options.tabSize``` and the ```editor.options.insertSpaces``` APIs. I also left the opportunity to set the custom indent. 

I think it will be more convenient.